### PR TITLE
Move clippy check to use a pre-made action

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,24 @@
+name: Rust
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: cargo build --verbose
+    - name: Run clippy
+      run: cargo clippy
+    - name: Run tests
+      run: cargo test --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,7 +18,8 @@ jobs:
     - uses: actions/checkout@v2
     - name: Build
       run: cargo build --verbose
-    - name: Run clippy
-      run: cargo clippy
     - name: Run tests
       run: cargo test --verbose
+    - name: clippy-check
+      uses: LoliGothick/clippy-check@v0.2.1
+


### PR DESCRIPTION
This pre-made action has the benefit of indicating clippy warnings in PRs.